### PR TITLE
Fix non-optimized build with GCC by disabling always_inline

### DIFF
--- a/ao.h
+++ b/ao.h
@@ -82,7 +82,7 @@ typedef struct
 #if defined(_MSC_VER)
 #define INLINE __forceinline
 #elif defined(__GNUC__)
-#define INLINE inline __attribute__((always_inline))
+#define INLINE inline
 #elif defined(_MWERKS_)
 #define INLINE inline
 #elif defined(__powerc)


### PR DESCRIPTION
When trying to build this on my linux machine, it failed to build due to the always_inline flag.

I don't think we can define inlines with the `always_inline` flag unless they are defined in the header files, or at least that was my understanding of the following error:

```
cc -c -g -fPIC -DLSB_FIRST -DEMU_COMPILE -DEMU_LITTLE_ENDIAN -I. -Ispu/  -o eng_psf.o eng_psf.c
cc -c -g -fPIC -DLSB_FIRST -DEMU_COMPILE -DEMU_LITTLE_ENDIAN -I. -Ispu/  -o eng_psf2.o eng_psf2.c
cc -c -g -fPIC -DLSB_FIRST -DEMU_COMPILE -DEMU_LITTLE_ENDIAN -I. -Ispu/  -o psx_hw.o psx_hw.c
cc -c -g -fPIC -DLSB_FIRST -DEMU_COMPILE -DEMU_LITTLE_ENDIAN -I. -Ispu/  -o psx.o psx.c
psx.c:269:17: warning: ‘mips_set_cp0r’ is static but used in inline function ‘mips_delayed_branch’ which is not static
  269 |                 mips_set_cp0r( mipscpu, CP0_BADVADDR, n_adr );
      |                 ^~~~~~~~~~~~~
psx.c:268:17: warning: ‘mips_exception’ is static but used in inline function ‘mips_delayed_branch’ which is not static
  268 |                 mips_exception( mipscpu, EXC_ADEL );
      |                 ^~~~~~~~~~~~~~
In function ‘mips_set_cp0r’,
    inlined from ‘mips_delayed_branch’ at psx.c:269:3:
psx.c:237:20: error: inlining failed in call to ‘always_inline’ ‘mips_set_cp0r’: function not considered for inlining
  237 | INLINE static void mips_set_cp0r( MIPS_CPU_CONTEXT *mipscpu, int reg, uint32_t value )
      |                    ^~~~~~~~~~~~~
psx.c:249:25: note: called from here
  249 |                         mips_set_cp0r( mipscpu, CP0_BADVADDR, mipscpu->pc );
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:15: psx.o] Error 1
```

I could be mistaken here, but this fixed the building on my system. 